### PR TITLE
Eval line if selection is empty

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,14 @@ const main = () => {
 		}
 	});
 
-	const sortedSelections = editor.selections.slice().sort((a, b) => {
+	const selections = editor.selections.slice();
+
+	if (selections.length === 1 && selections[0].isEmpty) {
+		const line = editor.document.lineAt(selections[0].start.line);
+		selections[0] = new vscode.Selection(line.range.start, line.range.end);
+	}
+
+	const sortedSelections = selections.sort((a, b) => {
 		if (a.start.line < b.start.line) return -1;
 		if (a.start.line > b.start.line) return 1;
 		if (a.start.character < b.start.character) return -1;


### PR DESCRIPTION
This lets you evaluate the current line without having to select it first, saving one keystroke. 

It does not affect existing users of the extension because before, an empty selection would do nothing.